### PR TITLE
Platform free

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,7 +163,6 @@ name = "embedded-nano-mesh"
 version = "0.0.1"
 dependencies = [
  "arduino-hal 0.1.0 (git+https://github.com/rahix/avr-hal?rev=7dfa6d322b9df98b2d98afe0e14a97afe0187ac1)",
- "avr-device",
  "embedded-hal",
  "heapless",
  "nb 0.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ panic-halt = "0.2.0"
 ufmt = "0.1.2"
 nb = "0.1.3"
 heapless = { version = "0.7.0", features = ["serde", "ufmt-impl"] }
-avr-device = "0.5.1"
 embedded-hal = "0.2.7"
 platform-millis = { git = "https://github.com/boshtannik/platform-millis.git" }
 platform-millis-arduino-nano = { git = "https://github.com/boshtannik/platform-millis-arduino-nano.git" }

--- a/examples/send_transaction_in_a_loop.rs
+++ b/examples/send_transaction_in_a_loop.rs
@@ -38,7 +38,7 @@ fn main() -> ! {
             3000 as ms,
         ) {
             Ok(()) => {
-                ufmt::uwriteln!(&mut ArduinoNanoSerial::default(), "Transaction sent").unwrap();
+                ufmt::uwriteln!(&mut ArduinoNanoSerial::default(), "Transaction done").unwrap();
             }
             Err(_) => {
                 ufmt::uwriteln!(&mut ArduinoNanoSerial::default(), "Transaction failed").unwrap()

--- a/src/mesh_lib/node/mod.rs
+++ b/src/mesh_lib/node/mod.rs
@@ -392,12 +392,12 @@ impl Node {
         }
 
         if (!is_send_queue_full) && (!is_transit_queue_full) {
-            return Ok(());
+            Ok(())
+        } else {
+            Err(NodeUpdateError {
+                is_send_queue_full,
+                is_transit_queue_full,
+            })
         }
-
-        Err(NodeUpdateError {
-            is_send_queue_full,
-            is_transit_queue_full,
-        })
     }
 }

--- a/src/mesh_lib/node/mod.rs
+++ b/src/mesh_lib/node/mod.rs
@@ -1,5 +1,3 @@
-use core::cell::RefCell;
-
 mod constants;
 mod packet;
 mod receiver;
@@ -8,7 +6,6 @@ mod timer;
 mod transmitter;
 mod types;
 
-use avr_device::interrupt::Mutex;
 pub use packet::{AddressType, MULTICAST_RESERVED_IDENTIFIER};
 use platform_serial::PlatformSerial;
 pub use router::PacketState;
@@ -17,14 +14,11 @@ pub use types::NodeString;
 pub use packet::{meta_data::PacketMetaData, LifeTimeType, PacketDataBytes};
 
 use self::{
-    router::{ErrCase, OkCase, PacketRouter},
-    types::{PacketDataQueue, PacketQueue},
+    router::{PacketLifetimeEnded, PacketRouter, RouteResult},
+    types::PacketDataQueue,
 };
 
 use platform_millis::{ms, PlatformTime};
-
-pub static GLOBAL_MUTEXED_CELLED_PACKET_QUEUE: Mutex<RefCell<PacketQueue>> =
-    Mutex::new(RefCell::new(PacketQueue::new()));
 
 /// The main structure of the library to use communication
 /// in the mesh network. The node works in the manner of listening
@@ -56,9 +50,9 @@ pub struct Node {
 }
 
 /// Error that can be returned by `Node` `update` method.
-pub enum NodeUpdateError {
-    ReceivingQueueIsFull,
-    TransitQueueIsFull,
+pub struct NodeUpdateError {
+    pub is_send_queue_full: bool,
+    pub is_transit_queue_full: bool,
 }
 
 /// Error that can be returned by `Node` `send` method.
@@ -324,9 +318,7 @@ impl Node {
     fn _send(&mut self, packet_meta_data: PacketMetaData) -> Result<(), SendError> {
         match self.transmitter.send(packet_meta_data) {
             Ok(_) => Ok(()),
-            Err(transmitter::TransmitterError::PacketQueueIsFull) => {
-                Err(SendError::SendingQueueIsFull)
-            }
+            Err(transmitter::PacketQueueIsFull) => Err(SendError::SendingQueueIsFull),
         }
     }
 
@@ -364,23 +356,48 @@ impl Node {
             None => return Ok(()),
         };
 
-        let reached_destination_packet = match self.packet_router.route(packet_to_handle) {
-            Ok(ok_case) => match ok_case {
-                OkCase::Handled => return Ok(()),
-                OkCase::Received(packet) => packet,
-            },
-            Err(err_case) => match err_case {
-                ErrCase::TransitQueueIsFull => return Err(NodeUpdateError::TransitQueueIsFull),
-                ErrCase::PacketLifetimeEnded => return Ok(()),
-            },
-        };
+        let (received_packet, transit_packet): (Option<PacketMetaData>, Option<PacketMetaData>) =
+            match self.packet_router.route(packet_to_handle) {
+                Ok(ok_case) => match ok_case {
+                    RouteResult::Received(packet) => (Some(packet), None),
+                    RouteResult::Transit(transit) => (None, Some(transit)),
+                    RouteResult::ReceivedAndTransit { received, transit } => {
+                        (Some(received), Some(transit))
+                    }
+                },
+                Err(PacketLifetimeEnded) => (None, None),
+            };
 
-        match self
-            .received_packet_meta_data_queue
-            .push_back(reached_destination_packet)
-        {
-            Ok(()) => Ok(()),
-            Err(_) => Err(NodeUpdateError::ReceivingQueueIsFull),
+        let (mut is_send_queue_full, mut is_transit_queue_full): (bool, bool) = (false, false);
+
+        if let Some(received_packet) = received_packet {
+            match self
+                .received_packet_meta_data_queue
+                .push_back(received_packet)
+            {
+                Ok(()) => (),
+                Err(_) => {
+                    is_send_queue_full = true;
+                }
+            }
         }
+
+        if let Some(transit_packet) = transit_packet {
+            match self.transmitter.send_transit(transit_packet) {
+                Ok(_) => (),
+                Err(transmitter::PacketTransitQueueIsFull) => {
+                    is_transit_queue_full = true;
+                }
+            }
+        }
+
+        if (!is_send_queue_full) && (!is_transit_queue_full) {
+            return Ok(());
+        }
+
+        Err(NodeUpdateError {
+            is_send_queue_full,
+            is_transit_queue_full,
+        })
     }
 }

--- a/src/mesh_lib/node/packet/trait_implementations/data_packer.rs
+++ b/src/mesh_lib/node/packet/trait_implementations/data_packer.rs
@@ -5,14 +5,16 @@ use super::super::Packet;
 
 impl DataPacker for Packet {
     fn pack(packet_meta_data: PacketMetaData) -> Self {
-        Packet::new(
+        let mut result = Packet::new(
             packet_meta_data.source_device_identifier,
             packet_meta_data.destination_device_identifier,
             packet_meta_data.packet_id,
             packet_meta_data.lifetime,
             packet_meta_data.spec_state,
             packet_meta_data.data,
-        )
+        );
+        result.set_ignore_duplication_flag(packet_meta_data.filter_out_duplication);
+        result
     }
 
     fn unpack(self) -> PacketMetaData {

--- a/src/mesh_lib/node/router/mod.rs
+++ b/src/mesh_lib/node/router/mod.rs
@@ -1,11 +1,8 @@
 pub use super::packet::PacketState;
 
 use super::{
-    packet::{
-        DataPacker, Packet, PacketMetaData, PacketMetaDataError, StateMutator,
-        MULTICAST_RESERVED_IDENTIFIER,
-    },
-    AddressType, GLOBAL_MUTEXED_CELLED_PACKET_QUEUE,
+    packet::{PacketMetaData, PacketMetaDataError, StateMutator, MULTICAST_RESERVED_IDENTIFIER},
+    AddressType,
 };
 
 /// Structure which keeps logic of routing of the packets
@@ -19,41 +16,22 @@ pub struct PacketRouter {
     current_device_identifier: AddressType,
 }
 
-pub enum OkCase {
-    Handled,
+pub enum RouteResult {
     Received(PacketMetaData),
+    Transit(PacketMetaData),
+    ReceivedAndTransit {
+        received: PacketMetaData,
+        transit: PacketMetaData,
+    },
 }
 
-pub enum ErrCase {
-    TransitQueueIsFull,
-    PacketLifetimeEnded,
-}
+pub struct PacketLifetimeEnded;
 
 impl PacketRouter {
     pub fn new(current_device_identifier: AddressType) -> Self {
         Self {
             current_device_identifier,
         }
-    }
-
-    fn push_to_transit_queue(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        let _ = ::avr_device::interrupt::free(|cs| {
-            match GLOBAL_MUTEXED_CELLED_PACKET_QUEUE
-                .borrow(cs)
-                .borrow_mut()
-                .push_back(<Packet as DataPacker>::pack(packet_meta_data))
-            {
-                Ok(_) => Ok(OkCase::Handled),
-                Err(_) => Err(ErrCase::TransitQueueIsFull),
-            }
-        });
-        Ok(OkCase::Handled)
-    }
-
-    /// This method is used to handle the packet, as the packet
-    /// that have reached it's final destination.
-    fn handle_normal(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        return Ok(OkCase::Received(packet_meta_data));
     }
 
     /// This method is used to handle the packet, that was sent to the all
@@ -64,100 +42,55 @@ impl PacketRouter {
     /// reached it's destination, and
     /// * Checks if packet can be transferred further, and if so - transfers it further into the
     /// network.
-    fn handle_multicast(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        let original_packet_meta_data = packet_meta_data.clone();
-        let packet_decreased_lifettime = match packet_meta_data.deacrease_lifetime() {
-            Ok(packet_meta_data) => packet_meta_data,
-            Err(_) => return Err(ErrCase::PacketLifetimeEnded),
+    fn handle_multicast(
+        &self,
+        packet_meta_data: PacketMetaData,
+    ) -> Result<RouteResult, PacketLifetimeEnded> {
+        let received = packet_meta_data.clone();
+        let transit: Option<PacketMetaData> = match packet_meta_data.deacrease_lifetime() {
+            Ok(packet_meta_data) => Some(packet_meta_data),
+            Err(PacketMetaDataError::PacketLifetimeEnded) => None,
         };
-        match self.push_to_transit_queue(packet_decreased_lifettime) {
-            Ok(OkCase::Handled) => return Ok(OkCase::Received(original_packet_meta_data)),
-            other_err => return other_err,
+        if let Some(transit) = transit {
+            return Ok(RouteResult::ReceivedAndTransit { received, transit });
         }
+        return Ok(RouteResult::Received(received));
     }
 
-    /// This method is used to handle the ping packet, that was sent to the
-    /// current device.
-    ///
-    /// It does:
-    /// * Gets the packet, that was sent to the current device.
-    /// * Decreases lifetime of the packet, and transfers it back to the sender.
-    fn handle_ping(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        let original_packet_meta_data = packet_meta_data.clone();
-        let packet_decreased_lifettime = match packet_meta_data.deacrease_lifetime() {
-            Ok(packet_decreased_lifettime) => packet_decreased_lifettime,
-            Err(_) => return Err(ErrCase::PacketLifetimeEnded),
-        };
-        let mutated_packet_meta_data = packet_decreased_lifettime.mutated();
-        self.push_to_transit_queue(mutated_packet_meta_data)?;
-        Ok(OkCase::Received(original_packet_meta_data))
-    }
-
-    /// This method is used to handle the pong packet, that was sent to the
-    /// current device.
-    fn handle_pong(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        self.handle_normal(packet_meta_data)
-    }
-
-    /// This method is used to handle the send transaction packet, that was sent to the
-    /// current device.
-    fn handle_send_transaction(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        let packet_decreased_lifettime = match packet_meta_data.deacrease_lifetime() {
-            Ok(packet) => packet,
-            Err(_) => return Err(ErrCase::PacketLifetimeEnded),
-        };
-        let mutated_decreased_packet = packet_decreased_lifettime.mutated();
-        self.push_to_transit_queue(mutated_decreased_packet)
-    }
-
-    /// This method is used to handle the accept transaction packet, that was sent to the
-    /// current device.
-    fn handle_accept_transaction(
+    fn keep_copy_and_prepare_transit(
         &self,
         packet_meta_data: PacketMetaData,
-    ) -> Result<OkCase, ErrCase> {
-        let packet_decreased_lifettime = match packet_meta_data.deacrease_lifetime() {
-            Ok(packet) => packet,
-            Err(_) => return Err(ErrCase::PacketLifetimeEnded),
-        };
-        let mutated_decreased_packet = packet_decreased_lifettime.mutated();
-        self.push_to_transit_queue(mutated_decreased_packet)
+    ) -> Result<RouteResult, PacketLifetimeEnded> {
+        let received = packet_meta_data.clone();
+        let transit = packet_meta_data.mutated();
+        Ok(RouteResult::ReceivedAndTransit { received, transit })
     }
 
-    /// This method is used to handle the accept transaction packet, that was sent to the
-    /// current device.
-    fn handle_init_transaction(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
-        let original_packet_meta_data = packet_meta_data.clone();
-        let mutated_packet_meta_data = packet_meta_data.mutated();
-        self.push_to_transit_queue(mutated_packet_meta_data)?;
-        Ok(OkCase::Received(original_packet_meta_data))
-    }
-
-    /// This method is used to handle the finish transaction packet, that was sent to the
-    /// current device.
-    fn handle_finish_transaction(
-        &self,
-        packet_meta_data: PacketMetaData,
-    ) -> Result<OkCase, ErrCase> {
-        Ok(OkCase::Received(packet_meta_data))
-    }
-
-    /// This method is used to route the packet.
+    /// This method is routes the packet.
     /// It does:
-    /// * Checks if the packet is for the current device, or multicast and handles it.
+    /// * Checks if the packet is addressed current device, or is multicast - and handles it.
     /// or
     /// * Checks if the packet can be transferred further, and if so - transfers it further into
     /// the transit queue.
-    pub fn route(&self, packet_meta_data: PacketMetaData) -> Result<OkCase, ErrCase> {
+    pub fn route(
+        &self,
+        packet_meta_data: PacketMetaData,
+    ) -> Result<RouteResult, PacketLifetimeEnded> {
         if packet_meta_data.is_destination_identifier_reached(self.current_device_identifier) {
             match packet_meta_data.spec_state {
-                PacketState::Normal => self.handle_normal(packet_meta_data),
-                PacketState::Ping => self.handle_ping(packet_meta_data),
-                PacketState::Pong => self.handle_pong(packet_meta_data),
-                PacketState::SendTransaction => self.handle_send_transaction(packet_meta_data),
-                PacketState::AcceptTransaction => self.handle_accept_transaction(packet_meta_data),
-                PacketState::InitTransaction => self.handle_init_transaction(packet_meta_data),
-                PacketState::FinishTransaction => self.handle_finish_transaction(packet_meta_data),
+                PacketState::Normal => Ok(RouteResult::Received(packet_meta_data)), // No need
+                PacketState::Ping => self.keep_copy_and_prepare_transit(packet_meta_data),
+                PacketState::Pong => Ok(RouteResult::Received(packet_meta_data)),
+                PacketState::SendTransaction => {
+                    Ok(RouteResult::Transit(packet_meta_data.mutated()))
+                }
+                PacketState::AcceptTransaction => {
+                    Ok(RouteResult::Transit(packet_meta_data.mutated()))
+                }
+                PacketState::InitTransaction => {
+                    self.keep_copy_and_prepare_transit(packet_meta_data)
+                }
+                PacketState::FinishTransaction => Ok(RouteResult::Received(packet_meta_data)),
             }
         } else if packet_meta_data.is_destination_identifier_reached(MULTICAST_RESERVED_IDENTIFIER)
         {
@@ -165,11 +98,9 @@ impl PacketRouter {
         } else {
             let packet_decreased_lifettime = match packet_meta_data.deacrease_lifetime() {
                 Ok(packet_decreased_lifettime) => packet_decreased_lifettime,
-                Err(PacketMetaDataError::PacketLifetimeEnded) => {
-                    return Err(ErrCase::PacketLifetimeEnded)
-                }
+                Err(PacketMetaDataError::PacketLifetimeEnded) => return Err(PacketLifetimeEnded), // Shit happens.
             };
-            self.push_to_transit_queue(packet_decreased_lifettime)
+            Ok(RouteResult::Transit(packet_decreased_lifettime))
         }
     }
 }


### PR DESCRIPTION
The main thing which was forgotten -is to cut off out of code which made code more free of  platform. Main job was done on removing out the shared queue between distant parts of the application, in order not to use static shared memory, that can be interrupted, which might cause data loss. Instead - more monolith code was made. As the side effect of code rewriting - so much boilerplate code was cut off, during this - one potential bug was found and fixed. That bug might lead filter_out_duplication flag loss on re-transmission of some special packet - which might lead to jam the network ether. Also the router code was redesigned and redundant and unnecessary code calls were removed. In the end, binary size shrank on 1 Kb, which i think potentially (not tested) have shrank RAM memory needed during stack calls.