### PR TITLE
Ms wraparound fix

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2022-07-10"
+channel = "stable"
 components = ["rust-src"]
 profile = "minimal"

--- a/src/mesh_lib/node/mod.rs
+++ b/src/mesh_lib/node/mod.rs
@@ -318,7 +318,7 @@ impl Node {
         M: Fn() -> ms,
     {
         let mut current_time = millis_provider();
-        let wait_end_time = current_time + timeout;
+        let start_time = current_time;
 
         while let Some(_) = self.receive() {} // Flush out all messages in the queuee.
 
@@ -342,7 +342,7 @@ impl Node {
             },
         };
 
-        while current_time < wait_end_time {
+        while current_time.wrapping_sub(start_time) < timeout {
             let _ = self.update(interface_driver, current_time);
 
             if let Some(answer) = self.receive() {

--- a/src/mesh_lib/node/receiver/packet_filter.rs
+++ b/src/mesh_lib/node/receiver/packet_filter.rs
@@ -89,3 +89,84 @@ impl Filter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mesh_lib::node::packet::{Packet, PacketDataBytes, PacketState};
+
+    // Construct a minimal packet with ignore_duplication_flag set.
+    // Unique ID is derived from (source_device_identifier, id).
+    fn make_packet(source: u8, id: u8) -> Packet {
+        Packet::new(
+            source,
+            2,
+            id,
+            1,
+            PacketState::Normal,
+            true,
+            PacketDataBytes::new(),
+        )
+    }
+
+    #[test]
+    fn duplicate_detected_within_ignore_period() {
+        let mut filter = Filter::new();
+        let t: ms = 1000;
+        let packet = make_packet(1, 0);
+        assert!(filter.filter_out_duplicated(packet.clone(), t).is_ok());
+        filter.update(t + RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD - 1);
+        assert!(filter
+            .filter_out_duplicated(packet, t + RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD - 1)
+            .is_err());
+    }
+
+    #[test]
+    fn entry_expires_after_ignore_period() {
+        let mut filter = Filter::new();
+        let t: ms = 1000;
+        let packet = make_packet(1, 0);
+        assert!(filter.filter_out_duplicated(packet.clone(), t).is_ok());
+        filter.update(t + RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD + 1);
+        // Entry gone — same packet can be re-registered
+        assert!(filter
+            .filter_out_duplicated(packet, t + RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD + 1)
+            .is_ok());
+    }
+
+    #[test]
+    fn duplicate_detected_within_period_across_u32_wraparound() {
+        let mut filter = Filter::new();
+        // 500ms before overflow
+        let near_max: ms = u32::MAX - 500;
+        let packet = make_packet(1, 0);
+        assert!(filter
+            .filter_out_duplicated(packet.clone(), near_max)
+            .is_ok());
+
+        let t_100ms = near_max.wrapping_add(100);
+        filter.update(t_100ms);
+        assert!(
+            filter.filter_out_duplicated(packet, t_100ms).is_err(),
+            "entry evicted after 100ms; old code overflows deadline to 499 then fires immediately"
+        );
+    }
+
+    #[test]
+    fn entry_expires_after_period_across_u32_wraparound() {
+        let mut filter = Filter::new();
+        // 500ms before overflow
+        let near_max: ms = u32::MAX - 500;
+        let packet = make_packet(1, 0);
+        assert!(filter
+            .filter_out_duplicated(packet.clone(), near_max)
+            .is_ok());
+
+        let t_after = near_max.wrapping_add(RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD + 1);
+        filter.update(t_after);
+        assert!(
+            filter.filter_out_duplicated(packet, t_after).is_ok(),
+            "entry not evicted after 1001ms across wraparound"
+        );
+    }
+}

--- a/src/mesh_lib/node/receiver/packet_filter.rs
+++ b/src/mesh_lib/node/receiver/packet_filter.rs
@@ -13,7 +13,7 @@ pub enum RegistrationError {
 
 struct PacketIgnorancePeriod {
     pub packet_unique_id: PacketUniqueId,
-    pub timeout: ms,
+    pub registered_at: ms,
 }
 
 type RegistrationEntryVec = Vec<PacketIgnorancePeriod, RECEIVER_FILTER_REGISTRATION_SIZE>;
@@ -52,7 +52,9 @@ impl Filter {
         let mut index_to_remove: Option<usize> = None;
 
         for (index, entry) in self.entry_registration_vec.iter().enumerate() {
-            if current_time > entry.timeout {
+            if current_time.wrapping_sub(entry.registered_at)
+                > RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD
+            {
                 index_to_remove.replace(index);
                 break;
             }
@@ -80,7 +82,7 @@ impl Filter {
 
         let new_entry = PacketIgnorancePeriod {
             packet_unique_id: packet_unique_identifier,
-            timeout: current_time + RECEIVER_FILTER_DUPLICATE_IGNORE_PERIOD,
+            registered_at: current_time,
         };
 
         match self.entry_registration_vec.push(new_entry) {

--- a/src/mesh_lib/node/timer/mod.rs
+++ b/src/mesh_lib/node/timer/mod.rs
@@ -25,3 +25,54 @@ impl Timer {
         self.last_speak_time = current_time;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PERIOD: ms = 100;
+
+    #[test]
+    fn does_not_speak_before_period_elapses() {
+        let mut timer = Timer::new(PERIOD);
+        timer.record_speak_time(1000);
+        assert!(!timer.is_time_to_speak(1099));
+    }
+
+    #[test]
+    fn speaks_when_period_elapses() {
+        let mut timer = Timer::new(PERIOD);
+        timer.record_speak_time(1000);
+        assert!(timer.is_time_to_speak(1100));
+    }
+
+    #[test]
+    fn does_not_speak_before_period_elapses_across_u32_wraparound() {
+        let mut timer = Timer::new(PERIOD);
+        // last_speak 50ms before u32 overflow
+        let last_speak: ms = u32::MAX - 50;
+        timer.record_speak_time(last_speak);
+        // 99ms later — wraps to u32::MAX - 50 + 99 = 48
+        let current = last_speak.wrapping_add(PERIOD - 1);
+        assert!(
+            !timer.is_time_to_speak(current),
+            "fired after only {}ms; old code: ({} + {}) overflows to {}, then {} > {} is true",
+            PERIOD - 1,
+            last_speak,
+            PERIOD,
+            last_speak.wrapping_add(PERIOD),
+            current,
+            last_speak.wrapping_add(PERIOD),
+        );
+    }
+
+    #[test]
+    fn speaks_after_period_elapses_across_u32_wraparound() {
+        let mut timer = Timer::new(PERIOD);
+        let last_speak: ms = u32::MAX - 50;
+        timer.record_speak_time(last_speak);
+        // exactly 100ms later — wraps to 49
+        let current = last_speak.wrapping_add(PERIOD);
+        assert!(timer.is_time_to_speak(current));
+    }
+}

--- a/src/mesh_lib/node/timer/mod.rs
+++ b/src/mesh_lib/node/timer/mod.rs
@@ -17,7 +17,7 @@ impl Timer {
     /// Tells if the time since last speak is enough to speak
     /// into the ether again.
     pub fn is_time_to_speak(&self, current_time: ms) -> bool {
-        current_time > { self.last_speak_time + self.listen_period }
+        current_time.wrapping_sub(self.last_speak_time) >= self.listen_period
     }
 
     /// Records current time as last speak time.


### PR DESCRIPTION
This closes #17 by adding tests which fail when wrapping arithmetic is not used but pass when using wrapping arithmetic.

This PR also fixes the Cargo.lock version 4 error that happens when using the outdated rust-toolchain version specified in the toml config.