### PR TITLE
Visibility changes

### DIFF
--- a/src/mesh_lib/mod.rs
+++ b/src/mesh_lib/mod.rs
@@ -2,5 +2,5 @@ mod node;
 
 pub use node::{
     ms, ExactAddressType, GeneralAddressType, IdType, LifeTimeType, Node, NodeConfig, NodeString,
-    NodeUpdateError, PacketDataBytes, PacketState, SendError, SpecialSendError,
+    NodeUpdateError, Packet, PacketDataBytes, PacketState, SendError, SpecialSendError,
 };

--- a/src/mesh_lib/node/mod.rs
+++ b/src/mesh_lib/node/mod.rs
@@ -302,6 +302,12 @@ impl Node {
         )
     }
 
+    /// Return the address of a node
+    /// Used for serial connections to learn which node is connected via serial
+    pub fn get_address(&self) -> ExactAddressType {
+        self.my_address
+    }
+
     fn _special_send<I, M>(
         &mut self,
         data: PacketDataBytes,

--- a/src/mesh_lib/node/mod.rs
+++ b/src/mesh_lib/node/mod.rs
@@ -302,12 +302,6 @@ impl Node {
         )
     }
 
-    /// Return the address of a node
-    /// Used for serial connections to learn which node is connected via serial
-    pub fn get_address(&self) -> ExactAddressType {
-        self.my_address
-    }
-
     fn _special_send<I, M>(
         &mut self,
         data: PacketDataBytes,

--- a/src/mesh_lib/node/packet/mod.rs
+++ b/src/mesh_lib/node/packet/mod.rs
@@ -30,7 +30,7 @@ pub use types::PacketState;
 #[derive(Clone)]
 pub struct Packet {
     pub source_device_identifier: AddressType,
-    pub destination_device_identifier: AddressType,
+    destination_device_identifier: AddressType,
     pub id: IdType,
     lifetime: LifeTimeType,
     flags: FlagsType,

--- a/src/mesh_lib/node/packet/mod.rs
+++ b/src/mesh_lib/node/packet/mod.rs
@@ -30,8 +30,8 @@ pub use types::PacketState;
 #[derive(Clone)]
 pub struct Packet {
     pub source_device_identifier: AddressType,
-    destination_device_identifier: AddressType,
-    id: IdType,
+    pub destination_device_identifier: AddressType,
+    pub id: IdType,
     lifetime: LifeTimeType,
     flags: FlagsType,
     data_length: DataLengthType,


### PR DESCRIPTION
Hello again, I've made some changes but I am unsure how amicable you are to accepting them.

These add a function for determining a node's address and change the visibility of `Packet` and its members `destination_device_identifier` and `id`.

I am working with a research team in a university to build mesh network sensors for studying forest fires (among other environmental phenomenon). We have one node connected via USB serial to read data from multiple mesh nodes spread across an area that provide sensor data.

Knowing the connected node's address allows our USB serial daemon to provide us with that knowledge. Making `Packet` public allows us to keep track of which nodes provide what data. Making `id`s of `Packet`s public lets us ensure we do not insert duplicates into our database, and `destination_device_identifier` allows us to collect metrics on mesh network performance.

Our daemon can be found [here](https://github.com/coffee-and-telesense/meshtastic-telemetry-daemon-rs/tree/embedded-nano-mesh), we are in the process of swapping from Meshtastic to your project since it fits our use case better. You can see the telemetry packet types being sketched out [here](https://github.com/coffee-and-telesense/nano-mesh-telemetry).

Let me know your thoughts and I can make any changes, if you do not want to accept these at all then I will probably maintain a fork.